### PR TITLE
[#39] Allow multiple CSS properties to be transitioned

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,10 +226,10 @@ Often your permanent elements depend on the hyperlink clicked. Just specify the 
 
 ### Element transitions
 
-In a lot of cases it can be useful to apply custom CSS transitions to specific elements when the page changes. This works especially well with background colors of persisted elements, but can be used for any CSS property on any element.
+In a lot of cases it can be useful to apply custom CSS transitions to specific elements when the page changes. This works especially well with background colors of persisted elements, but can be used for any CSS property on any element. Multiple properties can be transitioned using using comma separated values.
 
 ```html
-<header data-turbolinks-animate-persist-itself="true" data-turbolinks-animate-transition="background-color">
+<header data-turbolinks-animate-persist-itself="true" data-turbolinks-animate-transition="background-color,opacity">
   <!-- ... -->
 </header>
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -164,9 +164,9 @@ window.TurbolinksAnimate = window.TurbolinksAnimate || new function() {
         return;
       }
 
-      properties.forEach(() => {
-        newElement.style[cssPropertyToCamelCase(properties[i])] = getComputedStyle(element).getPropertyValue(properties[i]);
-      }
+      properties.forEach((property) => {
+        newElement.style[cssPropertyToCamelCase(property)] = getComputedStyle(element).getPropertyValue(property);
+      });
     });
   };
   
@@ -174,9 +174,9 @@ window.TurbolinksAnimate = window.TurbolinksAnimate || new function() {
     document.querySelectorAll('[data-turbolinks-animate-transition]').forEach((element) => {
       setTimeout(() => {
         let properties = element.dataset.turbolinksAnimateTransition.split(',');
-        for (var i = 0; i < properties.length; i++) {
-          element.style[cssPropertyToCamelCase(properties[i])] = null;
-        }
+        properties.forEach((property) => {
+          element.style[cssPropertyToCamelCase(property)] = null;
+        });
       }, 1);
     });
   };

--- a/src/index.js
+++ b/src/index.js
@@ -175,7 +175,7 @@ window.TurbolinksAnimate = window.TurbolinksAnimate || new function() {
     document.querySelectorAll('[data-turbolinks-animate-transition]').forEach((element) => {
       setTimeout(() => {
         let property = element.dataset.turbolinksAnimateTransition;
-        let properties = property.split(',');
+        let properties = element.dataset.turbolinksAnimateTransition.split(',');
         for (var i = 0; i < properties.length; i++) {
           element.style[cssPropertyToCamelCase(properties[i])] = null;
         }

--- a/src/index.js
+++ b/src/index.js
@@ -165,7 +165,7 @@ window.TurbolinksAnimate = window.TurbolinksAnimate || new function() {
       }
 
       let properties = property.split(',');
-      for (var i = 0; i < properties.length; i++) {
+      properties.forEach(() => {
         newElement.style[cssPropertyToCamelCase(properties[i])] = getComputedStyle(element).getPropertyValue(properties[i]);
       }
     });

--- a/src/index.js
+++ b/src/index.js
@@ -152,7 +152,7 @@ window.TurbolinksAnimate = window.TurbolinksAnimate || new function() {
 
   this.prepareTransition = (newBody) => {
     document.querySelectorAll('[data-turbolinks-animate-transition]').forEach((element) => {
-      let property = element.dataset.turbolinksAnimateTransition,
+      let properties = element.dataset.turbolinksAnimateTransition.split(','),
         matchingElements = newBody.querySelectorAll(element.tagName + '[data-turbolinks-animate-transition]'),
         newElement = null;
 
@@ -164,7 +164,6 @@ window.TurbolinksAnimate = window.TurbolinksAnimate || new function() {
         return;
       }
 
-      let properties = property.split(',');
       properties.forEach(() => {
         newElement.style[cssPropertyToCamelCase(properties[i])] = getComputedStyle(element).getPropertyValue(properties[i]);
       }
@@ -174,7 +173,6 @@ window.TurbolinksAnimate = window.TurbolinksAnimate || new function() {
   this.transition = () => {
     document.querySelectorAll('[data-turbolinks-animate-transition]').forEach((element) => {
       setTimeout(() => {
-        let property = element.dataset.turbolinksAnimateTransition;
         let properties = element.dataset.turbolinksAnimateTransition.split(',');
         for (var i = 0; i < properties.length; i++) {
           element.style[cssPropertyToCamelCase(properties[i])] = null;

--- a/src/index.js
+++ b/src/index.js
@@ -164,12 +164,22 @@ window.TurbolinksAnimate = window.TurbolinksAnimate || new function() {
         return;
       }
 
-      newElement.style[cssPropertyToCamelCase(property)] = getComputedStyle(element).getPropertyValue(property);
+      let properties = property.split(',');
+      for (var i = 0; i < properties.length; i++) {
+        newElement.style[cssPropertyToCamelCase(properties[i])] = getComputedStyle(element).getPropertyValue(properties[i]);
+      }
     });
   };
+  
   this.transition = () => {
     document.querySelectorAll('[data-turbolinks-animate-transition]').forEach((element) => {
-      setTimeout(() => element.style[cssPropertyToCamelCase(element.dataset.turbolinksAnimateTransition)] = null, 1);
+      setTimeout(() => {
+        let property = element.dataset.turbolinksAnimateTransition;
+        let properties = property.split(',');
+        for (var i = 0; i < properties.length; i++) {
+          element.style[cssPropertyToCamelCase(properties[i])] = null;
+        }
+      }, 1);
     });
   };
 


### PR DESCRIPTION
Resolves #39 

Additional thoughts on #28 

Loop through the list of properties to be animated and add them as individual styles to the transitioned element. Properties can be comma separated in the data attribute. Does not affect the default behavior if only one property is specified.